### PR TITLE
Substitutes MPL for MP11

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Poly Visitor is a header only library.
     * Clang 3.5.0
     * GCC 4.8.4
 * Header only dependencies:    
-  * [Boost.Any](http://www.boost.org/doc/libs/1_64_0/doc/html/any.html)
-  * [Boost.MPL](http://www.boost.org/doc/libs/1_64_0/libs/mpl/doc/index.html)
+  * [Boost.Any](https://www.boost.org/doc/libs/1_67_0/doc/html/any.html)
+  * [Boost.MP11](https://www.boost.org/doc/libs/1_67_0/libs/mp11/doc/html/mp11.html)
 
 ## Demos and tests
 1. Compile with [Boost.Build](http://www.boost.org/build/):
@@ -175,4 +175,4 @@ The classic C++ runtime polymorphism is an intrusive solution with inheritance a
 
 
 ## Acknowledgements
-This work is based on the implementation described in *"Modern C++ Design: Generic Programming and Design Patterns Applied"* by Andrei Alexandrescu. The interface and some ideas are based on [Boost.Variant](http://www.boost.org/doc/libs/1_64_0/doc/html/variant.html) and [Mapbox Variant](https://github.com/mapbox/variant). The idea about the `match()` convenience is from [daniel-j-h](https://gist.github.com/daniel-j-h).
+This work is based on the implementation described in *"Modern C++ Design: Generic Programming and Design Patterns Applied"* by Andrei Alexandrescu. The interface and some ideas are based on [Boost.Variant](https://www.boost.org/doc/libs/1_67_0/doc/html/variant.html) and [Mapbox Variant](https://github.com/mapbox/variant). The idea about the `match()` convenience is from [daniel-j-h](https://gist.github.com/daniel-j-h).

--- a/include/poly_visitor/base_visitor.hpp
+++ b/include/poly_visitor/base_visitor.hpp
@@ -2,16 +2,14 @@
 
 #include "poly_visitor/detail/base_visitor.hpp"
 
-#include <boost/mpl/vector.hpp>
-
-#include <type_traits>
+#include <boost/mp11/list.hpp>
 
 namespace poly_visitor {
     
 template<typename... Visitables>
 struct base_visitor : detail::base_visitor_hierarchy<Visitables...>
 {
-    using visitables = boost::mpl::vector<Visitables...>;
+    using visitables = boost::mp11::mp_list<Visitables...>;
 };
 
 }

--- a/include/poly_visitor/detail/base_visitor.hpp
+++ b/include/poly_visitor/detail/base_visitor.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "poly_visitor/detail/empty_base.hpp"
+
 #include <boost/any.hpp>
-#include <boost/mpl/empty_base.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/inherit_linearly.hpp>
+#include <boost/mp11/algorithm.hpp>
 
 namespace poly_visitor { namespace detail {
 
@@ -17,7 +17,7 @@ struct base_visitor : Base
 };
 
 template<typename Visitable>
-struct base_visitor<boost::mpl::empty_base, Visitable>
+struct base_visitor<empty_base, Visitable>
 {
     virtual boost::any visit(Visitable&) = 0;
     virtual boost::any visit(const Visitable&) = 0;
@@ -26,10 +26,11 @@ struct base_visitor<boost::mpl::empty_base, Visitable>
 
 template<typename... Visitables>
 struct base_visitor_hierarchy
-    : boost::mpl::inherit_linearly<
-          typename boost::mpl::vector<Visitables...>,
-          detail::base_visitor<boost::mpl::_1, boost::mpl::_2>
-      >::type
+    : boost::mp11::mp_fold<
+        boost::mp11::mp_list<Visitables...>,
+        empty_base,
+        base_visitor
+    >
 {
 };
         

--- a/include/poly_visitor/detail/empty_base.hpp
+++ b/include/poly_visitor/detail/empty_base.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace poly_visitor { namespace detail {
+
+struct empty_base{};
+
+}}

--- a/include/poly_visitor/detail/visitor.hpp
+++ b/include/poly_visitor/detail/visitor.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "poly_visitor/detail/empty_base.hpp"
+
 #include <boost/any.hpp>
-#include <boost/mpl/empty_base.hpp>
-#include <boost/mpl/inherit_linearly.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/bind.hpp>
 
 namespace poly_visitor { namespace detail {
 
@@ -23,8 +25,7 @@ struct visitor : Base
 template<typename Visitable,
          typename VisitorWrapper,
          typename UserBaseVisitor>
-struct visitor<boost::mpl::empty_base, Visitable, VisitorWrapper,
-               UserBaseVisitor> : UserBaseVisitor
+struct visitor<empty_base, Visitable, VisitorWrapper, UserBaseVisitor> : UserBaseVisitor
 {
     using UserBaseVisitor::visit;
     boost::any visit(Visitable& o) override
@@ -36,11 +37,17 @@ struct visitor<boost::mpl::empty_base, Visitable, VisitorWrapper,
 
 template<typename Visitables, typename VisitorWrapper, typename BaseVisitor>
 struct visitor_hierarchy
-    : boost::mpl::inherit_linearly<
-          Visitables,
-          detail::visitor<boost::mpl::_1, boost::mpl::_2,
-                          VisitorWrapper, BaseVisitor>
-      >::type
+    : boost::mp11::mp_fold_q<
+        Visitables,
+        empty_base,
+        boost::mp11::mp_bind<
+            visitor,
+            boost::mp11::_1,
+            boost::mp11::_2,
+            VisitorWrapper,
+            BaseVisitor
+        >
+    >
 {
 };
 

--- a/include/poly_visitor/detail/visitor_const.hpp
+++ b/include/poly_visitor/detail/visitor_const.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "poly_visitor/detail/empty_base.hpp"
+
 #include <boost/any.hpp>
-#include <boost/mpl/empty_base.hpp>
-#include <boost/mpl/inherit_linearly.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/bind.hpp>
 
 namespace poly_visitor { namespace detail {
 
@@ -22,8 +24,7 @@ struct visitor_const : Base
 template<typename Visitable,
          typename VisitorWrapper,
          typename UserBaseVisitor>
-struct visitor_const<boost::mpl::empty_base, Visitable, VisitorWrapper,
-                     UserBaseVisitor> : UserBaseVisitor
+struct visitor_const<empty_base, Visitable, VisitorWrapper, UserBaseVisitor> : UserBaseVisitor
 {
     using UserBaseVisitor::visit;
     boost::any visit(Visitable& o) override
@@ -34,11 +35,17 @@ struct visitor_const<boost::mpl::empty_base, Visitable, VisitorWrapper,
 
 template<typename Visitables, typename VisitorWrapper, typename BaseVisitor>
 struct visitor_const_hierarchy
-    : boost::mpl::inherit_linearly<
-          Visitables,
-          detail::visitor_const<boost::mpl::_1, boost::mpl::_2,
-                                VisitorWrapper, BaseVisitor>
-      >::type
+    : boost::mp11::mp_fold_q<
+        Visitables,
+        empty_base,
+        boost::mp11::mp_bind<
+            visitor_const,
+            boost::mp11::_1,
+            boost::mp11::_2,
+            VisitorWrapper,
+            BaseVisitor
+        >
+    >
 {
 };
         


### PR DESCRIPTION
- compiling MPL can be a lot more expensive than MPL11.
On a project with 49 types and no precompiled mpl headers, using MP11 instead of MPL
reduced compilation time in 9%.
MPL11 has precompiled headers to solve this problem,
but there is a limit of 50 types by default. If the user wants more,
they will have to produce the precompiled headers.
MP11 doesn't have that limit, and it takes advantage of features
introduced in C++11.